### PR TITLE
Backport python 3.11 multiprocessing fix

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,4 +3,4 @@ black~=24.3
 flake8~=5.0
 flake8-bugbear~=22.9
 isort~=5.7
-pytest~=5.4.3
+pytest~=8.2


### PR DESCRIPTION
Backport https://github.com/python/cpython/commit/6f94bbf77e28966fe0d789b5aa477f547ccddae9, which fixes https://github.com/python/cpython/issues/104536.

[ML-8061](https://iguazio.atlassian.net/browse/ML-8061)