### PR TITLE
Improve error handling

### DIFF
--- a/taoswswrap/tdengine_connection.py
+++ b/taoswswrap/tdengine_connection.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import multiprocessing
-import traceback
 import os
+import traceback
 
 import taosws
 from _queue import Empty

--- a/taoswswrap/tdengine_connection.py
+++ b/taoswswrap/tdengine_connection.py
@@ -28,6 +28,9 @@ class QueryResult:
     def __eq__(self, other):
         return self.data == other.data and self.fields == other.fields
 
+    def __repr__(self):
+        return f"QueryResult({self.data}, {self.fields})"
+
 
 class Field:
     def __init__(self, name, type, bytes):
@@ -37,6 +40,9 @@ class Field:
 
     def __eq__(self, other):
         return self.name == other.name and self.type == other.type and self.bytes == other.bytes
+
+    def __repr__(self):
+        return f"Field({self.name}, {self.type}, {self.bytes})"
 
 
 class TDEngineError(Exception):

--- a/tests/taoswswrap/test_tdengine_connection.py
+++ b/tests/taoswswrap/test_tdengine_connection.py
@@ -13,15 +13,11 @@
 # limitations under the License.
 
 import os
+from datetime import datetime, timezone
 
 import pytest
 
-from taoswswrap.tdengine_connection import (
-    Field,
-    QueryResult,
-    TDEngineConnection,
-    TDEngineError,
-)
+from taoswswrap.tdengine_connection import Field, TDEngineConnection, TDEngineError
 
 connection_string = os.getenv("TAOSWS_CONNECTION_STRING")
 
@@ -45,10 +41,15 @@ def test_tdengine_connection():
         ],
         query="SELECT * FROM mytable",
     )
-    assert res == QueryResult(
-        [("2024-10-09 11:33:06.455 +08:00", 1.0)],
-        [Field("column1", "TIMESTAMP", 8), Field("column2", "FLOAT", 4)],
+    assert res.fields == [Field("column1", "TIMESTAMP", 8), Field("column2", "FLOAT", 4)]
+    assert len(res.data) == 1
+    data = res.data[0]
+    assert len(data) == 2
+    col1, col2 = data
+    assert datetime.strptime(col1, "%Y-%m-%d %H:%M:%S.%f %z").astimezone(timezone.utc) == datetime(
+        2024, 10, 9, 3, 33, 6, 455000, tzinfo=timezone.utc
     )
+    assert col2 == 1
 
 
 @pytest.mark.skipif(not is_tdengine_defined(), reason="TDEngine is not defined")


### PR DESCRIPTION
* Retry on error even if a timeout did not occur
* Preserve original error trace
* Kill process on timeout rather than terminating it (SIGKILL instead of SIGTERM)
* Fix test time zone handling